### PR TITLE
Update opensearch dockerfile to download the plugin.

### DIFF
--- a/opensearch/Dockerfile
+++ b/opensearch/Dockerfile
@@ -1,5 +1,4 @@
 FROM opensearchproject/opensearch:2.11.1
 
 # Install the opensearch-ubl plugin.
-# COPY /path/to/opensearch-ubl.zip /tmp/
-# RUN /usr/share/opensearch/bin/opensearch-plugin install file:/tmp/opensearch-ubl.zip
+RUN /usr/share/opensearch/bin/opensearch-plugin install https://github.com/o19s/opensearch-ubl/releases/download/0.0.1/opensearch-ubl.zip


### PR DESCRIPTION
Adds the plugin to OpenSearch during the `docker compose build`.