### PR TITLE
Upgrading to OS and OS Dashboards to 2.12 and plugin 0.0.7 built for OS 2.12

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       http.cors.allow-headers: X-Requested-With,X-Auth-Token,Content-Type,Content-Length,Authorization,test,access-control-allow-headers,x-search-query,X-Search-Id,X-Search-Filters,X-ubl-query-id,X-ubl-store,X-ubl-user-id,X-ubl-session-id,x-search-client,Access-Control-Expose-Headers
       # indexes faster if we don't log each row (i.e. logger.level: debug/info)
       logger.level: info
+      OPENSEARCH_INITIAL_ADMIN_PASSWORD: Mysupersecretpassword_123
     ulimits:
       memlock:
         soft: -1

--- a/opensearch-dashboards/Dockerfile
+++ b/opensearch-dashboards/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensearchproject/opensearch-dashboards:2.11.1
+FROM opensearchproject/opensearch-dashboards:2.12.0
 
 # Disable security.
 RUN /usr/share/opensearch-dashboards/bin/opensearch-dashboards-plugin remove securityDashboards

--- a/opensearch/Dockerfile
+++ b/opensearch/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensearchproject/opensearch:2.11.1
+FROM opensearchproject/opensearch:2.12.0
 
 # Install the opensearch-ubi plugin.
-RUN /usr/share/opensearch/bin/opensearch-plugin install https://github.com/o19s/opensearch-ubi/releases/download/0.0.6/opensearch-ubi.zip
+RUN /usr/share/opensearch/bin/opensearch-plugin install https://github.com/o19s/opensearch-ubi/releases/download/0.0.7/opensearch-ubi.zip


### PR DESCRIPTION
Upgrading to OS 2.12 and plugin 0.0.7.

If this impacts any upcoming demo it can wait to be merged.

This is for #16 