### PR TITLE
 Adding a cost field to products.

### DIFF
--- a/opensearch/transform_data.py
+++ b/opensearch/transform_data.py
@@ -1,5 +1,6 @@
 import sys
 import json
+import random
 
 
 n = len(sys.argv)
@@ -13,5 +14,6 @@ data = json.load(fIn)
 with open(fOut, 'w', encoding='utf8') as fOut:
 	for row in data:
 		row['primary_ean'] = row['ean'][0]
+		row['cost'] = random.randint(1,int(row['price']))
 		fOut.write('{ "index" : {"_id" : "' + row['id'] + '"}}\n')
 		fOut.write(json.dumps(row) + '\n')


### PR DESCRIPTION
Adds a `cost` field. It's value is a random number between 1 and the `price`.

Example:

```
{
  "id": "3920564",
  "name": "006R90321",
  "title": "Xerox 006R90321 toner cartridge Original Black 6 pc(s)",
  "ean": [
    "0095205603217"
  ],
  "short_description": "Toner (6 Per Box) for CopyCentre C65 Digital Copier",
  "img_high": "http://images.icecat.biz/img/gallery/img_3920564_high_1472618727_1208_7091.jpg",
  "img_low": "http://images.icecat.biz/img/gallery_lows/img_3920564_low_1472618727_2493_7091.jpg",
  "img_500x500": "http://images.icecat.biz/img/gallery_mediums/img_3920564_medium_1472618727_1445_7091.jpg",
  "img_thumb": "http://images.icecat.biz/img/gallery_thumbs/img_3920564_thumb_1472618727_2925_7091.jpg",
  "date_released": "2009-12-10T00:00:00Z",
  "supplier": "Xerox",
  "price": 4995,
  "attr_t_type": "Original",
  "attr_t_printing_colours": "Black",
  "attr_t_print_technology": "Laser printing",
  "attr_t_compatibility": "CopyCentre C65",
  "attr_n_quantity_per_pack": 6,
  "attr_n_black_toner_page_yield": 23000,
  "primary_ean": "0095205603217",
  "cost": 991
}
```