### PR TITLE
Adding --batch to allow for installing without a prompt.

### DIFF
--- a/opensearch/Dockerfile
+++ b/opensearch/Dockerfile
@@ -1,4 +1,4 @@
 FROM opensearchproject/opensearch:2.14.0
 
 # Install the opensearch-ubi plugin.
-RUN /usr/share/opensearch/bin/opensearch-plugin install https://github.com/o19s/opensearch-ubi/releases/download/release-v0.0.12.1-os2.14.0/opensearch-ubi-plugin-v0.0.12.1-os2.14.0.zip
+RUN /usr/share/opensearch/bin/opensearch-plugin install --batch https://github.com/o19s/opensearch-ubi/releases/download/release-v0.0.12.1-os2.14.0/opensearch-ubi-plugin-v0.0.12.1-os2.14.0.zip


### PR DESCRIPTION
This is to avoid a prompt when installing the plugin because the plugin require more security settings. Without this, the docker image build will fail because you can't respond to the prompt.

This is required due to the security changes in https://github.com/o19s/opensearch-ubi/pull/187/files#diff-214b5d6612e51e2474aafa928918b67b571bfa31d6f4e398248840e5437714e9