### PR TITLE
Track Impressions + Fix Query Id generation

### DIFF
--- a/reactivesearch/src/App.js
+++ b/reactivesearch/src/App.js
@@ -1,4 +1,4 @@
-import React, {Component} from "react";
+import React, { Component } from "react";
 import {
   ReactiveBase,
   DataSearch,
@@ -22,7 +22,9 @@ const event_server = "http://localhost:9090"; // Middleware
 const search_server = "http://localhost:9090"; // Send all queries through Middleware
 
 const APPLICATION = "Chorus";
-const client_id = 'CLIENT-eeed-43de-959d-90e6040e84f9'; // demo client id
+const client_id = ((sessionStorage.hasOwnProperty('client_id')) ?
+          sessionStorage.getItem('client_id')
+          : 'CLIENT-' + generateGuid());
 const session_id = ((sessionStorage.hasOwnProperty('session_id')) ?
           sessionStorage.getItem('session_id')
           : 'SESSION-' + generateGuid());
@@ -30,6 +32,8 @@ const session_id = ((sessionStorage.hasOwnProperty('session_id')) ?
 const object_id_field = 'asin'; // When we refer to a object by it's ID, this describes what the ID field represents
 
 const ubiClient = new  UbiClient(event_server);
+
+clearQueryId(); // clear out any existing query_id
 
 function addToCart(item) {
   let shopping_cart = sessionStorage.getItem("shopping_cart");
@@ -40,7 +44,7 @@ function addToCart(item) {
   cart.textContent = shopping_cart;
   
  var event = new UbiEvent(APPLICATION, 'add_to_cart', client_id, session_id, getQueryId(), 
-    new UbiEventAttributes('product', item.primary_ean, item.title, item), 
+    new UbiEventAttributes('asin', item.asin, item.title, item), 
     item.title + ' (' + item.id + ')');
   
   event.message_type = 'CONVERSION';
@@ -66,6 +70,10 @@ function generateQueryId(){
   return query_id;
 }
 
+function clearQueryId(){
+  sessionStorage.setItem('query_id', null);
+}
+
 function getQueryId(){
   return sessionStorage.getItem('query_id');
 }
@@ -85,6 +93,32 @@ function generateGuid() {
 };
 
 class App extends Component {
+
+  componentDidMount() {
+    this.observer = new IntersectionObserver((entries) => {
+        entries.forEach(entry => {
+            if (entry.isIntersecting) {
+                console.log(`${entry.target.innerText} is now visible in the viewport!`);
+                var event = new UbiEvent(APPLICATION, 'impression', client_id, session_id, getQueryId(), 
+                  new UbiEventAttributes('asin', entry.target.attributes.asin.value, entry.target.attributes.title, {rank: entry.target.attributes.rank}), 
+                  'impression made on doc ranked ' + entry.target.attributes.rank.value);
+                event.message_type = 'IMPRESSION';               
+                console.log(event);
+                ubiClient.trackEvent(event);
+                // Optionally unobserve the button after visibility
+                this.observer.unobserve(entry.target);
+            }
+        });
+    });
+  }
+
+
+  handleRef = (node) => {
+       if (node) {
+           this.observer.observe(node); // Observe the node when it is mounted
+       }
+   };
+  
 
   render(){
   return (
@@ -196,15 +230,20 @@ class App extends Component {
               marginTop: "35px"
             }}
             componentId="searchbox"
-            placeholder="Search for products, brands or EAN"
+            placeholder="Search for products, brands or ASIN"
             autosuggest={false}
             dataField={["id", "title", "category", "bullets", "description", "attrs.Brand", "attrs.Color"]}
-            onValueChange={
+            onKeyPress={
               function(value) {
-                
-                //generate a new query id to track events against
+                // With every keypress generate a new query id and store it in the session to track events against. 
+                // We currently don't have any debouncing or triggering only on return.
+                // this ensures we generate the new query_id before the customQuery() function is called.
+                // onValueChange is called AFTER customQuery() function is called.
                 const query_id = generateQueryId();
-                
+              }
+            }
+            onValueChange={
+              function (value) {
                 // If you do not have the UBI plugin enabled in your search engine, then you need
                 // to track the query request yourself.
                 // const query = new UbiQueryRequest(APPLICATION, client_id, query_id, value, "_id", {});
@@ -216,7 +255,7 @@ class App extends Component {
                 
                 // We log the event to ubi_events but that isn't strictly required since
                 // the plugin in OpenSearch will log a record into ubi_queries.
-                const event = new UbiEvent(APPLICATION, 'search', client_id, session_id, query_id, null, value);
+                const event = new UbiEvent(APPLICATION, 'search', client_id, session_id, getQueryId(), null, value);
                 event.message_type = 'QUERY'
                 console.log(event)
                 ubiClient.trackEvent(event);
@@ -236,7 +275,7 @@ class App extends Component {
                 const extJsonDisabledUBI = {
             
                 }
-                const extJson = {
+                let extJson = {
                   ubi: {
                     query_id: getQueryId(),
                     user_query: value,
@@ -315,7 +354,7 @@ class App extends Component {
             style={{ textAlign: "center" }}
             render={({ data }) => (
               <ReactiveList.ResultCardsWrapper>
-                {data.map((item) => (
+                {data.map((item, index) => (
                   <ResultCard key={item._id}>
                     <ResultCard.Image
                       style={{
@@ -329,14 +368,21 @@ class App extends Component {
                       }}
                     />
                     <ResultCard.Description>
-                      {item.price + " $ | " + item.attrs.Brand}
+                      {item.price + " $ | "}
+                      {item.attrs.Brand ? item.attrs.Brand : ""}
                     </ResultCard.Description>
-                    <button style={{ fontSize:"14px", position:"relative" }} onClick ={
-                      function(el) {
-                        addToCart(item);
+                    <button 
+                      style={{ fontSize:"14px", position:"relative" }}       
+                      ref={this.handleRef}   
+                      rank={ index }
+                      asin={ item.asin }            
+                      onClick={
+                        function(el) {
+                          addToCart(item);
+                        }
                       }
-                    }>
-                      Add to <span style={{fontSize:24 }}> 🛒</span>
+                    >
+                      {index} Add to <span style={{fontSize:24 }}> 🛒</span>
                     </button>
                   </ResultCard>
                 ))}

--- a/reactivesearch/src/App.js
+++ b/reactivesearch/src/App.js
@@ -99,8 +99,10 @@ class App extends Component {
         entries.forEach(entry => {
             if (entry.isIntersecting) {
                 console.log(`${entry.target.innerText} is now visible in the viewport!`);
+                const rank = parseInt(entry.target.attributes.rank.value, 10)
+                const title = entry.target.attributes.title?.value || "";
                 var event = new UbiEvent(APPLICATION, 'impression', client_id, session_id, getQueryId(), 
-                  new UbiEventAttributes('asin', entry.target.attributes.asin.value, entry.target.attributes.title, {rank: entry.target.attributes.rank}), 
+                  new UbiEventAttributes('asin', entry.target.attributes.asin.value, title, {rank: rank}), 
                   'impression made on doc ranked ' + entry.target.attributes.rank.value);
                 event.message_type = 'IMPRESSION';               
                 console.log(event);
@@ -375,7 +377,8 @@ class App extends Component {
                       style={{ fontSize:"14px", position:"relative" }}       
                       ref={this.handleRef}   
                       rank={ index }
-                      asin={ item.asin }            
+                      asin={ item.asin }
+                      title={ item.title }            
                       onClick={
                         function(el) {
                           addToCart(item);

--- a/reactivesearch/src/App.js
+++ b/reactivesearch/src/App.js
@@ -206,10 +206,13 @@ class App extends Component {
                 const query_id = generateQueryId();
                 
                 // If you do not have the UBI plugin enabled in your search engine, then you need
-                // to track the query yourself.
-                // const query = new UbiQuery(APPLICATION, client_id, query_id, value, "_id", {});
-                // query.message_type = 'QUERY'
+                // to track the query request yourself.
+                // const query = new UbiQueryRequest(APPLICATION, client_id, query_id, value, "_id", {});
+                // console.log(query)
                 // ubiClient.trackQuery(query)
+                // 
+                // Don't forget to change the query to use ext: extJsonDisabledUBI instead of ext: extJson
+                // to make sure you don't double track the events, once in the ubiClient.trackQuery and once in the OS UBI plugin!
                 
                 // We log the event to ubi_events but that isn't strictly required since
                 // the plugin in OpenSearch will log a record into ubi_queries.
@@ -228,7 +231,11 @@ class App extends Component {
                 } else {
                   algo = 'keyword';
                 }
-                
+            
+                // no UBI clauses means no use of the OpenSearch UBI plugin.
+                const extJsonDisabledUBI = {
+            
+                }
                 const extJson = {
                   ubi: {
                     query_id: getQueryId(),

--- a/reactivesearch/src/App.js
+++ b/reactivesearch/src/App.js
@@ -12,7 +12,7 @@ import AlgoPicker from './custom/AlgoPicker';
 import ShoppingCartButton from './custom/ShoppingCartButton';
 import { UbiEvent } from './ubi/ubi';
 import { UbiEventAttributes } from './ubi/ubi'
-import { UbiQuery } from './ubi/ubi';
+import { UbiQueryRequest } from './ubi/ubi';
 import { UbiClient } from './ubi/ubi'
 import chorusLogo from './assets/chorus-logo.png';
 

--- a/reactivesearch/src/ubi/ubi.js
+++ b/reactivesearch/src/ubi/ubi.js
@@ -1,12 +1,21 @@
-/**
-ubi.js is downloaded from https://github.com/opensearch-project/user-behavior-insights/tree/main/ubi-javascript-collector.
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+ 
+/*
+ubi.js is sourced from https://github.com/opensearch-project/user-behavior-insights/tree/main/ubi-javascript-collector.
 */
 
 import axios from 'axios';
 
 /**
- * Methods and client to talk directly with the OpenSearch UBI plugin
- * for logging events
+ * Methods and client to manage tracking queries and events that follow the User Behavior Insights specification.
  */
 export class UbiClient {
     constructor(baseUrl) {

--- a/reactivesearch/src/ubi/ubi.js
+++ b/reactivesearch/src/ubi/ubi.js
@@ -33,21 +33,21 @@ export class UbiClient {
         this.verbose = 0; // Default value for verbose
     }
 
-    async trackEvent(e, message = null, message_type = null) {
+    async trackEvent(event, message = null, message_type = null) {
         if (message) {
-            if (e.message) {
-                e['extra_info'] = message;
+            if (event.message) {
+                event['extra_info'] = message;
                 if (message_type) {
-                    e['extra_info_type'] = message_type;
+                    event['extra_info_type'] = message_type;
                 }
             } else {
-                e.message = message;
-                e.message_type = message_type;
+                event.message = message;
+                event.message_type = message_type;
             }
         }
 
         // Data prepper wants an array of JSON.
-        let json = JSON.stringify([e]);
+        let json = JSON.stringify([event]);
         if (this.verbose > 0) {
             console.log('POSTing event: ' + json);
         }
@@ -55,23 +55,23 @@ export class UbiClient {
         return this._post(json, this.eventUrl);
     }
     
-    async trackQuery(e, message = null, message_type = null) {
+    async trackQuery(query, message = null, message_type = null) {
         if (message) {
-            if (e.message) {
-                e['extra_info'] = message;
+            if (query.message) {
+                query['extra_info'] = message;
                 if (message_type) {
-                    e['extra_info_type'] = message_type;
+                    query['extra_info_type'] = message_type;
                 }
             } else {
-                e.message = message;
-                e.message_type = message_type;
+                query.message = message;
+                query.message_type = message_type;
             }
         }
 
         // Data prepper wants an array of JSON.
-        let json = JSON.stringify([e]);
+        let json = JSON.stringify([query]);
         if (this.verbose > 0) {
-            console.log('POSTing event: ' + json);
+            console.log('POSTing query: ' + json);
         }
 
         return this._post(json,this.queryUrl);
@@ -146,25 +146,18 @@ export class UbiEventAttributes {
   }
 }
 
-export class UbiQuery {
+export class UbiQueryRequest {
   /**
-   * This maps to the UBI Query Specification at https://github.com/o19s/ubi
+   * This maps to the UBI Query Request Specification at https://github.com/o19s/ubi
    */
-  constructor(application, client_id, query_id, user_query, object_id_field, query_attributes = {}, message = null) {
+  constructor(application, client_id, query_id, user_query, object_id_field, query_attributes = {}) {
     this.application = application;
-    this.query_id = query_id;
-    this.user_query = user_query;        
+    this.query_id = query_id;    
     this.client_id = client_id;
+    this.user_query = user_query;        
+    this.query_attributes = query_attributes    
     this.object_id_field = object_id_field;
     this.timestamp = new Date().toISOString();
-    this.message_type = 'INFO';
-    this.message = message || '';     // Default to an empty string if no message
-    this.query_attributes = query_attributes
-  }
-
-  setMessage(message, message_type = 'INFO') {
-    this.message = message;
-    this.message_type = message_type;
   }
 
   /**


### PR DESCRIPTION
Too much happened too quick in this.  We now have impression tracking.  Also, had a bug that the customQuery would fire BEFORE onValueChange, which meant that we would use the PREVIOUS search everytime.  onKeyPress happens before customQuery, so we get the id, and the onValueChange happens after custom query, so we can travk the event.