### PR TITLE
include search quality eval dashboards into quickstart

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -315,6 +315,20 @@ curl -s GET http://localhost:9200/_tasks/$update_docs_task_id\n${RESET}"
 echo -e "${MAJOR}Installing User Behavior Insights Dashboards...\n${RESET}"
 curl -X POST "http://localhost:5601/api/saved_objects/_import?overwrite=true" -H "osd-xsrf: true" --form file=@opensearch-dashboards/ubi_dashboard.ndjson > /dev/null
 
+echo -e "${MAJOR}Fetching latest Search Result Quality Evaluation Dashboard, sample data and install script...\n${RESET}"
+# Dashbaords
+curl -s -o search_dashboard.ndjson https://raw.githubusercontent.com/o19s/opensearch-search-quality-evaluation/refs/heads/main/opensearch-dashboard-prototyping/search_dashboard.ndjson
+# Install script
+curl -s -o install_dashboards.sh https://raw.githubusercontent.com/o19s/opensearch-search-quality-evaluation/refs/heads/main/opensearch-dashboard-prototyping/install_dashboards.sh
+# sample data
+curl -s -o sample_data.ndjson https://raw.githubusercontent.com/o19s/opensearch-search-quality-evaluation/refs/heads/main/opensearch-dashboard-prototyping/sample_data.ndjson
+# mappings for search quality metrics sample data index
+curl -s -o sqe_metrics_mappings.json https://raw.githubusercontent.com/o19s/opensearch-search-quality-evaluation/refs/heads/main/opensearch-dashboard-prototyping/sqe_metrics_mappings.json
+
+echo -e "${MAJOR}Installing Search Result Quality Evaluation Dashboard...\n${RESET}"
+chmod +x install_dashboards.sh
+./install_dashboards.sh http://localhost:9200 http://localhost:5601
+
 # we start dataprepper as the last service to prevent it from creating the ubi_queries index using the wrong mappings.
 echo -e "${MAJOR}Starting Dataprepper...\n${RESET}"
 docker compose up -d --build dataprepper


### PR DESCRIPTION
Downloads necessary data from [search quality evaluation app repository](https://github.com/o19s/opensearch-search-quality-evaluation) and installs the dashboards together with some sample data.

